### PR TITLE
Refactors start/stop server

### DIFF
--- a/app/mcmgr/src/components/Home.vue
+++ b/app/mcmgr/src/components/Home.vue
@@ -11,11 +11,11 @@
         v-bind:id="server.id"
         v-for="server in servers"
       >
-        <span class="badge stopped" data-badge-caption="Stopped"></span>
+        <span class="badge" :class="server.status ? 'running' : 'stopped'" v-bind:data-badge-caption="server.status ? 'Running' : 'Stopped'"></span>
         {{ server.name }}
       </a>
     </div>
-    <Server v-bind:server="selectedServer"></Server>
+    <Server v-on:detectServerChange="fetchServers()" v-bind:server="selectedServer"></Server>
     <CreateServer v-on:createServer="fetchServers()"></CreateServer>
   </div>
 </template>
@@ -118,6 +118,14 @@ export default class Home extends Vue {
   color: white;
   font-weight: 700;
   border: 1px solid #c7425a;
+  border-radius: 5px;
+}
+
+.running {
+  background-color: #328319;
+  color: white;
+  font-weight: 700;
+  border: 1px solid #328319;
   border-radius: 5px;
 }
 </style>

--- a/server/createAdmin.sh
+++ b/server/createAdmin.sh
@@ -6,3 +6,4 @@ read -p "Enter an admin username: " ADMIN_USERNAME
 read -sp "Enter an admin password: " ADMIN_PASSWORD
 # RESULT=$(htpasswd -nBC 10 $ADMIN_USERNAME)
 node ./createAdmin.js "$ADMIN_USERNAME:$ADMIN_PASSWORD"
+printf "\n"

--- a/server/setup.sh
+++ b/server/setup.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 # make sure at least node 8 is being used
 # install node_modules
+printf "\n(Re)Installing npm modules...\n"
 npm install --save-dev
 
 # reset data dirs
+printf "\n(Re)Setting data directories...\n"
 rm -rf ../data/ ../data-test/
 mkdir ../data/ ../data-test/
 cp templates/servers.json ../data/servers.json
@@ -12,10 +14,14 @@ cp templates/users.json ../data/users.json
 cp templates/users.json ../data-test/users.json
 
 # reset dist
+printf "\n(Re)Compiling typescript watch dirs...\n"
 rm -rf dist
 tsc
 
 # make createAdmin script an executable
+printf "\nCreating admin account....\n"
 chmod +x ./createAdmin.sh
 ./createAdmin.sh
+
+printf "\nSuccessfully setup mcmgr server.\nUse 'npm start' to run production build.\nUse 'npm run dev' to run dev build.\n"
 

--- a/server/types/MCEventBus.d.ts
+++ b/server/types/MCEventBus.d.ts
@@ -5,7 +5,7 @@ export interface MCEventBusInterface {
 
     publish(event: MCEvent): void;
     subscribe(topic: string, subscriber: Function): string;
-    createEvent(desiredTopic: Topic, payload: any, successCallback?: Function, errorCallback?: Function): MCEvent;
+    createEvent(desiredTopic: Topic, payload: any, successCallback?: Function | null, errorCallback?: Function | null): MCEvent;
     getTopic(desiredTopic: Topic): Topic | null;
 }
 


### PR DESCRIPTION
This PR includes a handful of improvements to both server (primarily MCSM) and the view layer to provide support for dynamic status / pid updates and usage of serverId instead of pid to start/stop servers.